### PR TITLE
Add 'at' layout combinator

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <h1 style="font-family: Helvetica, sans-serif; text-align: center;">Doodle</h1>
 
 <div>
-    <canvas style="display: block; margin-left: auto; margin-right: auto;" id="canvas" width="255" height="255"/>
+    <canvas style="display: block; margin-left: auto; margin-right: auto;" id="canvas" width="400" height="400"/>
 </div>
 
 <script type="text/javascript" src="./js/target/scala-2.11/doodle-fastopt.js"></script>

--- a/js/src/main/scala/doodle/js/Draw.scala
+++ b/js/src/main/scala/doodle/js/Draw.scala
@@ -14,10 +14,10 @@ object Draw {
     val originX = canvas.width / 2
     val originY = canvas.height / 2
 
-    draw(img, originX, originY, DrawingContext.blackLines, ctx)
+    draw(img, Point(originX, originY), DrawingContext.blackLines, ctx)
   }
 
-  def draw(img: Image, originX: Double, originY: Double, context: DrawingContext, ctx: dom.CanvasRenderingContext2D): Unit = {
+  def draw(img: Image, origin: Point, context: DrawingContext, ctx: dom.CanvasRenderingContext2D): Unit = {
     def doStrokeAndFill() = {
       context.stroke.foreach {
         case Stroke(width, color, cap, join) => {
@@ -39,52 +39,52 @@ object Draw {
     img match {
       case Circle(r) =>
         ctx.beginPath()
-        ctx.arc(originX, originY, r, 0.0, Math.PI * 2)
+        ctx.arc(origin.x, origin.y, r, 0.0, Math.PI * 2)
         ctx.closePath()
         doStrokeAndFill()
       case Rectangle(w, h) =>
         ctx.beginPath()
-        ctx.rect(originX - w/2, originY - h/2, w, h)
+        ctx.rect(origin.x - w/2, origin.y - h/2, w, h)
         ctx.closePath()
         doStrokeAndFill()
       case Triangle(w, h) =>
         ctx.beginPath()
-        ctx.moveTo(originX      , originY - h/2)
-        ctx.lineTo(originX + w/2, originY + h/2)
-        ctx.lineTo(originX - w/2, originY + h/2)
+        ctx.moveTo(origin.x      , origin.y - h/2)
+        ctx.lineTo(origin.x + w/2, origin.y + h/2)
+        ctx.lineTo(origin.x - w/2, origin.y + h/2)
         ctx.closePath()
         doStrokeAndFill()
 
       case Overlay(t, b) =>
-        draw(b, originX, originY, context, ctx)
-        draw(t, originX, originY, context, ctx)
+        draw(b, origin, context, ctx)
+        draw(t, origin, context, ctx)
       case b @ Beside(l, r) =>
         val box = BoundingBox(b)
         val lBox = BoundingBox(l)
         val rBox = BoundingBox(r)
 
-        val lOriginX = originX + box.left + (lBox.width / 2)
-        val rOriginX = originX + box.right - (rBox.width / 2)
+        val lOriginX = origin.x + box.left + (lBox.width / 2)
+        val rOriginX = origin.x + box.right - (rBox.width / 2)
         // Beside always vertically centers l and r, so we don't need
         // to calculate center ys for l and r.
 
-        draw(l, lOriginX, originY, context, ctx)
-        draw(r, rOriginX, originY, context, ctx)
+        draw(l, Point(lOriginX, origin.y), context, ctx)
+        draw(r, Point(rOriginX, origin.y), context, ctx)
       case a @ Above(t, b) =>
         val box = BoundingBox(a)
         val tBox = BoundingBox(t)
         val bBox = BoundingBox(b)
 
-        val tOriginY = originY + box.top + (tBox.height / 2)
-        val bOriginY = originY + box.bottom - (bBox.height / 2)
+        val tOriginY = origin.y + box.top + (tBox.height / 2)
+        val bOriginY = origin.y + box.bottom - (bBox.height / 2)
 
-        draw(t, originX, tOriginY, context, ctx)
-        draw(b, originX, bOriginY, context, ctx)
-      case At((x, y), i) =>
-        draw(i, originX + x, originY + y, context, ctx) 
+        draw(t, Point(origin.x, tOriginY), context, ctx)
+        draw(b, Point(origin.x, bOriginY), context, ctx)
+      case At(vec, i) =>
+        draw(i, origin + vec, context, ctx) 
 
       case ContextTransform(f, i) =>
-        draw(i, originX, originY, f(context), ctx)
+        draw(i, origin, f(context), ctx)
     }
   }
 }

--- a/js/src/main/scala/doodle/js/Draw.scala
+++ b/js/src/main/scala/doodle/js/Draw.scala
@@ -80,6 +80,8 @@ object Draw {
 
         draw(t, originX, tOriginY, context, ctx)
         draw(b, originX, bOriginY, context, ctx)
+      case At((x, y), i) =>
+        draw(i, originX + x, originY + y, context, ctx) 
 
       case ContextTransform(f, i) =>
         draw(i, originX, originY, f(context), ctx)

--- a/jvm/src/main/scala/doodle/jvm/Draw.scala
+++ b/jvm/src/main/scala/doodle/jvm/Draw.scala
@@ -11,8 +11,7 @@ object Draw {
     val canvas = new JPanel {
       override def paintComponent(ctx: Graphics): Unit = Draw.draw(
         img,
-        getWidth/2,
-        getHeight/2,
+        Point(getWidth/2, getHeight/2),
         DrawingContext.blackLines,
         ctx.asInstanceOf[Graphics2D]
       )
@@ -24,10 +23,10 @@ object Draw {
     frame.setVisible(true)
   }
 
-  def draw(img: Image, originX: Double, originY: Double, context: DrawingContext, ctx: Graphics2D): Unit = {
+  def draw(img: Image, origin: Point, context: DrawingContext, ctx: Graphics2D): Unit = {
     def awtColor(color: Color): AwtColor = {
       val RGBA(r, g, b, a) = color.toRGBA
-      new AwtColor(r.get, g.get, b.get, (a.get * 255).toInt)
+      new AwtColor(r.get, g.get, b.get, a.toUnsignedByte.get)
     }
 
     def doStrokeAndFill(shape: Shape2D) = {
@@ -49,50 +48,50 @@ object Draw {
 
     img match {
       case Circle(r) =>
-        doStrokeAndFill(new Ellipse2D.Double(originX-r, originY-r, r*2, r*2))
+        doStrokeAndFill(new Ellipse2D.Double(origin.x-r, origin.y-r, r*2, r*2))
 
       case Rectangle(w, h) =>
-        doStrokeAndFill(new Rectangle2D.Double(originX - w/2, originY - h/2, w, h))
+        doStrokeAndFill(new Rectangle2D.Double(origin.x - w/2, origin.y - h/2, w, h))
 
       case Triangle(w, h) =>
         val path = new Path2D.Double()
-        path.moveTo(originX      , originY - h/2)
-        path.lineTo(originX + w/2, originY + h/2)
-        path.lineTo(originX - w/2, originY + h/2)
-        path.lineTo(originX      , originY - h/2)
+        path.moveTo(origin.x      , origin.y - h/2)
+        path.lineTo(origin.x + w/2, origin.y + h/2)
+        path.lineTo(origin.x - w/2, origin.y + h/2)
+        path.lineTo(origin.x      , origin.y - h/2)
         doStrokeAndFill(path)
 
       case Overlay(t, b) =>
-        draw(b, originX, originY, context, ctx)
-        draw(t, originX, originY, context, ctx)
+        draw(b, origin, context, ctx)
+        draw(t, origin, context, ctx)
 
       case b @ Beside(l, r) =>
         val box = BoundingBox(b)
         val lBox = BoundingBox(l)
         val rBox = BoundingBox(r)
 
-        val lOriginX = originX + box.left + (lBox.width / 2)
-        val rOriginX = originX + box.right - (rBox.width / 2)
+        val lOriginX = origin.x + box.left + (lBox.width / 2)
+        val rOriginX = origin.x + box.right - (rBox.width / 2)
         // Beside always vertically centers l and r, so we don't need
         // to calculate center ys for l and r.
 
-        draw(l, lOriginX, originY, context, ctx)
-        draw(r, rOriginX, originY, context, ctx)
+        draw(l, Point(lOriginX, origin.y), context, ctx)
+        draw(r, Point(rOriginX, origin.y), context, ctx)
       case a @ Above(t, b) =>
         val box  = BoundingBox(a)
         val tBox = BoundingBox(t)
         val bBox = BoundingBox(b)
 
-        val tOriginY = originY + box.top + (tBox.height / 2)
-        val bOriginY = originY + box.bottom - (bBox.height / 2)
+        val tOriginY = origin.y + box.top + (tBox.height / 2)
+        val bOriginY = origin.y + box.bottom - (bBox.height / 2)
 
-        draw(t, originX, tOriginY, context, ctx)
-        draw(b, originX, bOriginY, context, ctx)
-      case At((x, y), i) =>
-        draw(i, originX + x, originY + y, context, ctx) 
+        draw(t, Point(origin.x, tOriginY), context, ctx)
+        draw(b, Point(origin.x, bOriginY), context, ctx)
+      case At(vec, i) =>
+        draw(i, origin + vec, context, ctx) 
 
       case ContextTransform(f, i) =>
-        draw(i, originX, originY, f(context), ctx)
+        draw(i, origin, f(context), ctx)
     }
   }
 }

--- a/jvm/src/main/scala/doodle/jvm/Draw.scala
+++ b/jvm/src/main/scala/doodle/jvm/Draw.scala
@@ -88,6 +88,8 @@ object Draw {
 
         draw(t, originX, tOriginY, context, ctx)
         draw(b, originX, bOriginY, context, ctx)
+      case At((x, y), i) =>
+        draw(i, originX + x, originY + y, context, ctx) 
 
       case ContextTransform(f, i) =>
         draw(i, originX, originY, f(context), ctx)

--- a/shared/src/main/scala/doodle/Example.scala
+++ b/shared/src/main/scala/doodle/Example.scala
@@ -16,7 +16,7 @@ object Example {
 
   val levels = 4
 
-  def treeElement = {
+  def leavesElement = {
     val color = green.spin((Math.random() * 30).degrees)
       .darken((Math.random() * 0.1).clip)
       .desaturate((Math.random() * 0.1).clip)
@@ -25,17 +25,32 @@ object Example {
 
   def row(elements: Int): Image =
     elements match {
-      case 1 => bauble on treeElement
-      case n => bauble on treeElement beside row(n - 1)
+      case 1 => bauble on leavesElement
+      case n => bauble on leavesElement beside row(n - 1)
     }
 
-  def tree(levels: Int): Image =
+  def leaves(levels: Int): Image =
     levels match {
-      case 1 => treeElement
-      case n => row(n) below tree(n - 1)
+      case 1 => leavesElement
+      case n => row(n) below leaves(n - 1)
     }
 
-  val treeBackground = Triangle(40 * levels, 40 * levels) fillColor(darkGreen)
+  val leavesBackground = Triangle(40 * levels, 40 * levels) fillColor(darkGreen)
   val trunk = Rectangle(20,40) lineColor(brown) fillColor(brown)
-  val picture = goldBauble above (tree(levels) on treeBackground) above trunk
+  val tree = goldBauble above (leaves(levels) on leavesBackground) above trunk
+
+  def ringOfBaubles(total: Int): Image = {
+    val radius = 150
+    def buildRing(n: Int): Image = {
+      val angle =  math.Pi * 2 * n / total
+      val bauble = Circle(7) lineColor(red) fillColor(red) at (math.cos(angle) * radius, math.sin(angle) * radius)
+      n match {
+        case 0 => bauble
+        case n => bauble on buildRing(n - 1)
+      }
+    }
+    buildRing(total)
+  }
+
+  val picture = tree on ringOfBaubles(7)
 }

--- a/shared/src/main/scala/doodle/core/BoundingBox.scala
+++ b/shared/src/main/scala/doodle/core/BoundingBox.scala
@@ -55,7 +55,7 @@ object BoundingBox {
         (boxT.height + boxB.height) / 2
       )
 
-    case At((x, y), i) =>
+    case At(Vec(x, y), i) =>
       val inner = BoundingBox(i)
       // Because bounding boxes are required to be centered on the the
       // image they enclose, all we need to do is divide the x and y

--- a/shared/src/main/scala/doodle/core/BoundingBox.scala
+++ b/shared/src/main/scala/doodle/core/BoundingBox.scala
@@ -55,6 +55,21 @@ object BoundingBox {
         (boxT.height + boxB.height) / 2
       )
 
+    case At((x, y), i) =>
+      val inner = BoundingBox(i)
+      // Because bounding boxes are required to be centered on the the
+      // image they enclose, all we need to do is divide the x and y
+      // displacement evenly amongst the bounds of the inner bounding
+      // box.
+      val xAmount = Math.abs(x) / 2
+      val yAmount = Math.abs(y) / 2
+      BoundingBox(
+        inner.left - xAmount,
+        inner.top - yAmount,
+        inner.right + xAmount,
+        inner.bottom + yAmount
+      )
+
     case ContextTransform(f, i) =>
       BoundingBox(i)
   }

--- a/shared/src/main/scala/doodle/core/Image.scala
+++ b/shared/src/main/scala/doodle/core/Image.scala
@@ -16,6 +16,9 @@ sealed trait Image {
   def below(top: Image): Image =
     Above(top, this)
 
+  def at(x: Double, y: Double) =
+    At((x, y), this)
+
   def lineColor(color: Color): Image =
     ContextTransform(_.lineColor(color), this)
 
@@ -31,6 +34,7 @@ final case class Triangle(w: Double, h: Double) extends Image
 final case class Beside(l: Image, r: Image) extends Image
 final case class Above(l: Image, r: Image) extends Image
 final case class Overlay(t: Image, b: Image) extends Image
+final case class At(at: (Double, Double), i: Image) extends Image
 // final case class Path(elements: List[Path]) extends Image {
 //   def +:(elt: PathElement): Path =
 //     Path(elt +: elements)

--- a/shared/src/main/scala/doodle/core/Image.scala
+++ b/shared/src/main/scala/doodle/core/Image.scala
@@ -17,7 +17,7 @@ sealed trait Image {
     Above(top, this)
 
   def at(x: Double, y: Double) =
-    At((x, y), this)
+    At(Vec(x, y), this)
 
   def lineColor(color: Color): Image =
     ContextTransform(_.lineColor(color), this)
@@ -34,7 +34,7 @@ final case class Triangle(w: Double, h: Double) extends Image
 final case class Beside(l: Image, r: Image) extends Image
 final case class Above(l: Image, r: Image) extends Image
 final case class Overlay(t: Image, b: Image) extends Image
-final case class At(at: (Double, Double), i: Image) extends Image
+final case class At(at: Vec, i: Image) extends Image
 // final case class Path(elements: List[Path]) extends Image {
 //   def +:(elt: PathElement): Path =
 //     Path(elt +: elements)

--- a/shared/src/main/scala/doodle/core/Point.scala
+++ b/shared/src/main/scala/doodle/core/Point.scala
@@ -1,0 +1,6 @@
+package doodle.core
+
+final case class Point(x: Double, y: Double) {
+  def +(v: Vec): Point =
+    Point(this.x + v.x, this.y + v.y)
+}

--- a/shared/src/main/scala/doodle/core/Vec.scala
+++ b/shared/src/main/scala/doodle/core/Vec.scala
@@ -1,0 +1,6 @@
+package doodle.core
+
+/**
+ * A vector in 2D. We can't use the name `Vector` as Scala already uses it.
+ */
+final case class Vec(x: Double, y: Double)


### PR DESCRIPTION
Example

Circle(5) at (20, 20) on Circle(10)

This combinator allows you to layout an element at any position relative to
the local origin. This adds additional flexibility beyond what
on/above/beside offer, at the cost of more work for the user is
calculating layouts.

At layout also expands the bounding box to include the offset.