### PR TITLE
Trivial fix to AngleSpec unit test

### DIFF
--- a/js/src/test/scala/doodle/core/AngleSpec.scala
+++ b/js/src/test/scala/doodle/core/AngleSpec.scala
@@ -18,7 +18,7 @@ object AngleSpec extends TestSuite {
     "Conversions to/from normalized"-{
       for(i <- 1 to 100) {
         val original = Angle.turns(Math.random)
-        val converted = Angle.turns(original.toTurns.get)
+        val converted = Angle.turns(original.toTurns)
 
         assert(Math.abs(original.toRadians - converted.toRadians) < 0.1)
       }


### PR DESCRIPTION
Previously, running `sbt test` would introduce an error:

[error] /usr/local/google/home/namnguyen/tmp/doodle/js/src/test/scala/doodle/core/AngleSpec.scala:21: value get is not a member of Double
[error]         val converted = Angle.turns(original.toTurns.get)