### PR TITLE
Changing default line join to be Miter rather than Bevel for sharp corners

### DIFF
--- a/shared/src/main/scala/doodle/core/DrawingContext.scala
+++ b/shared/src/main/scala/doodle/core/DrawingContext.scala
@@ -45,7 +45,7 @@ object DrawingContext {
       lineWidth = Some(1.0),
       lineColor = Some(Color.white),
       lineCap = Some(Line.Cap.Butt),
-      lineJoin = Some(Line.Join.Bevel),
+      lineJoin = Some(Line.Join.Miter),
       fillColor = None
     )
   val blackLines =
@@ -53,7 +53,7 @@ object DrawingContext {
       lineWidth = Some(1.0),
       lineColor = Some(Color.black),
       lineCap = Some(Line.Cap.Butt),
-      lineJoin = Some(Line.Join.Bevel),
+      lineJoin = Some(Line.Join.Miter),
       fillColor = None
     )
 }


### PR DESCRIPTION
I've been enjoying the Creative Scala book a lot so far, but the pictures in the book didn't always match the pictures I was generating. I chalked it up to a platform-specific issue at first, but it bothered me enough at some point that I did some digging, and I'm pretty sure it's due to the stroke join being set to the [non-default](https://docs.oracle.com/javase/7/docs/api/java/awt/BasicStroke.html#BasicStroke%28float%29) "Bevel" type.
Example:
> (Triangle(100, 50) above Rectangle(80, 80) lineWidth 10).draw

Before change:
![before](https://cloud.githubusercontent.com/assets/34575/12047442/5db72c30-ae80-11e5-8808-f91da152c0ab.png)

After change:
![after](https://cloud.githubusercontent.com/assets/34575/12047444/5f572d6a-ae80-11e5-9f4b-507f5489ad01.png)
