### PR TITLE
Addition to README: drawing images when using doodle as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ initialCommands in console := """
 """.trim.stripMargin
 ~~~
 
+Note that, if you are using the older 0.1.0 release, the syntax for using the draw function is different.
+Drawing the same red circle that we did in the 'Getting Started' section above can be accomplished with the following:
+
+~~~ scala
+scala> draw(Circle(10).fillColor(Color.red))
+~~~
+
 [bintray-training]: https://bintray.com/underscoreio/training
 [doodle-releases]: https://bintray.com/underscoreio/training/doodle/view
 


### PR DESCRIPTION
Recently I tried to use doodle as a library, following the instructions
in the README. I got stuck at trying to draw shapes, however.

Fortunately, after spending a little bit of time talking in the glitter
thread I figured out why it wasn’t working - the current release,
0.1.0, uses the old draw function syntax.