### PR TITLE
Allow direct drawing on the Canvas

### DIFF
--- a/js/src/main/scala/doodle/js/SvgCanvas.scala
+++ b/js/src/main/scala/doodle/js/SvgCanvas.scala
@@ -7,24 +7,44 @@ import doodle.backend.{BoundingBox, Canvas}
 
 import org.scalajs.dom
 
-final case class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
+final class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
     extends Canvas {
   import scalatags.JsDom.styles.{font => cssFont}
   import scalatags.JsDom.{svgTags => svg}
   import scalatags.JsDom.svgAttrs
   import scalatags.JsDom.implicits._
 
+  var transforms: List[String] = List.empty
+
+  def pushTransform(tx: Transform): Unit = {
+    val svg = Svg.toSvgTransform(tx)
+    transforms = svg :: transforms
+  }
+
+  def popTransform(): Unit = {
+    transforms match {
+      case hd :: tl =>
+        transforms = tl
+      case Nil =>
+        // Do nothing
+        ()
+    }
+  }
+
+  def currentTransform =
+    svgAttrs.transform:=(transforms.reverse.mkString)
+
   def closedPath(context: DrawingContext, elements: List[PathElement]): Unit = {
     val dAttr = Svg.toSvgPath(elements) ++ "Z"
     val style = Svg.toStyle(context)
-    val elt = svg.path(svgAttrs.style:=style, svgAttrs.d:=dAttr).render
+    val elt = svg.path(currentTransform, svgAttrs.style:=style, svgAttrs.d:=dAttr).render
     root.appendChild(elt)
   }
 
   def openPath(context: DrawingContext, elements: List[PathElement]): Unit = {
     val dAttr = Svg.toSvgPath(elements)
     val style = Svg.toStyle(context)
-    val elt = svg.path(svgAttrs.style:=style, svgAttrs.d:=dAttr).render
+    val elt = svg.path(currentTransform, svgAttrs.style:=style, svgAttrs.d:=dAttr).render
     root.appendChild(elt)
   }
 
@@ -38,11 +58,12 @@ final case class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
       // bounding box origin is at the center of the text.
       val bottomLeft = Transform.translate(-boundingBox.width/2, -boundingBox.height/2)
       val fullTx = Transform.horizontalReflection andThen tx andThen bottomLeft
+      val svgTx = transforms.reverse.mkString ++ " " ++ Svg.toSvgTransform(fullTx)
       val font = FontMetrics.toCss(f)
       val elt = svg.text(svgAttrs.style:=style,
                          svgAttrs.x:=0,
                          svgAttrs.y:=0,
-                         svgAttrs.transform:=Svg.toSvgTransform(fullTx),
+                         svgAttrs.transform:=svgTx,
                          cssFont:=font,
                          characters).render
       root.appendChild(elt)

--- a/jvm/src/main/scala/doodle/jvm/Java2DCanvas.scala
+++ b/jvm/src/main/scala/doodle/jvm/Java2DCanvas.scala
@@ -5,6 +5,7 @@ import doodle.core._
 import doodle.core.transform.Transform
 import doodle.backend.{BoundingBox, Canvas}
 import java.awt.Graphics2D
+import java.awt.geom.AffineTransform
 
 final class Java2DCanvas(graphics: Graphics2D, center: Point, screenCenter: Point) extends Canvas {
 
@@ -23,6 +24,25 @@ final class Java2DCanvas(graphics: Graphics2D, center: Point, screenCenter: Poin
         .andThen(Transform.translate(screenCenter.x, screenCenter.y))
     )
   )
+
+  var transforms: List[AffineTransform] = List.empty
+
+  def pushTransform(tx: Transform): Unit = {
+    val affine = Java2D.toAffineTransform(tx)
+    transforms = graphics.getTransform() :: transforms
+    graphics.transform(affine)
+  }
+
+  def popTransform(): Unit = {
+    transforms match {
+      case hd :: tl =>
+        graphics.setTransform(hd)
+        transforms = tl
+      case Nil =>
+        // No transform to pop. Do nothing.
+        ()
+    }
+  }
 
   def openPath(context: DrawingContext, elements: List[PathElement]): Unit = {
     val path = Java2D.toPath2D(elements)

--- a/shared/src/main/scala/doodle/backend/Canvas.scala
+++ b/shared/src/main/scala/doodle/backend/Canvas.scala
@@ -14,6 +14,8 @@ import doodle.core.transform.Transform
   * This is essentially a Church encoding of the Finalised representation, minus the layout operators. Canvas allows *absolute* layout with minimum memory allocation, and is thus more efficient but less convenient than a deep embedding such as Finalised.
   */
 trait Canvas {
+  def pushTransform(tx: Transform): Unit
+  def popTransform(): Unit
   def openPath(context: DrawingContext, elements: List[PathElement]): Unit
   def closedPath(context: DrawingContext, elements: List[PathElement]): Unit
   def text(context: DrawingContext, tx: Transform, boundingBox: BoundingBox, characters: String): Unit
@@ -21,8 +23,8 @@ trait Canvas {
   // Derived methods
 
   /** Draw a circle on this [[Canvas]]. */
-  def circle(context: DrawingContext, tx: Transform, x: Double, y: Double, radius: Double): Unit = {
-    val elts = PathElement.circle(x, y, radius).map(_.transform(tx))
+  def circle(context: DrawingContext, x: Double, y: Double, radius: Double): Unit = {
+    val elts = PathElement.circle(x, y, radius)
     closedPath(context, elts)
   }
 }

--- a/shared/src/main/scala/doodle/backend/Finalised.scala
+++ b/shared/src/main/scala/doodle/backend/Finalised.scala
@@ -15,6 +15,9 @@ object Finalised {
   final case class OpenPath(context: DrawingContext, elements: List[PathElement], boundingBox: BoundingBox) extends Finalised
   final case class ClosedPath(context: DrawingContext, elements: List[PathElement], boundingBox: BoundingBox) extends Finalised
   final case class Text(context: DrawingContext, characters: String, boundingBox: BoundingBox) extends Finalised
+  final case class Draw(w: Double, h: Double, f: Canvas => Unit) extends Finalised {
+    val boundingBox = BoundingBox(-w/2, h/2, w/2, -h/2)
+  }
   final case class Beside(l: Finalised, r: Finalised) extends Finalised {
     val boundingBox = l.boundingBox beside r.boundingBox
   }
@@ -165,6 +168,9 @@ object Finalised {
           val bb =
             context.font.map(f => metrics(f, txt)).getOrElse(BoundingBox.empty)
           continue(cont(Text(context, txt, bb)))
+
+        case Image.Draw(w, h, f) =>
+          continue(cont(Draw(w, h, f)))
 
         case Image.Beside(l, r) =>
           binaryStep(l, r, context, Beside.apply _, cont)

--- a/shared/src/main/scala/doodle/backend/Render.scala
+++ b/shared/src/main/scala/doodle/backend/Render.scala
@@ -42,6 +42,14 @@ object Render {
 
           cont()
 
+        case r @ Draw(w, h, f) =>
+          val fullTx = transform.Transform.translate(origin.toVec) andThen tx
+          canvas.pushTransform(fullTx)
+          f(canvas)
+          canvas.popTransform()
+
+          cont()
+
         case On(t, b) =>
           continue(step(b, origin, tx){ () =>
                      continue(step(t, origin, tx){ () =>

--- a/shared/src/main/scala/doodle/core/Image.scala
+++ b/shared/src/main/scala/doodle/core/Image.scala
@@ -2,6 +2,7 @@ package doodle
 package core
 
 import doodle.core.font.Font
+import doodle.backend.Canvas
 
 sealed abstract class Image extends Product with Serializable {
   import Image._
@@ -96,6 +97,7 @@ object Image {
   final case class Circle(r: Double) extends Image
   final case class Rectangle(w: Double, h: Double) extends Image
   final case class Triangle(w: Double, h: Double) extends Image
+  final case class Draw(w: Double, h: Double, f: Canvas => Unit) extends Image
   final case class Beside(l: Image, r: Image) extends Image
   final case class Above(l: Image, r: Image) extends Image
   final case class On(t: Image, b: Image) extends Image
@@ -308,6 +310,9 @@ object Image {
       OpenPath(PathElement.moveTo(pt0) :: iter(pt0 :: points.toList))
     }
   }
+
+  def draw(width: Double, height: Double)(f: Canvas => Unit): Image =
+    Draw(width, height, f)
 
   def empty: Image =
     Empty

--- a/shared/src/main/scala/doodle/examples/SandSpline.scala
+++ b/shared/src/main/scala/doodle/examples/SandSpline.scala
@@ -5,32 +5,43 @@ import cats.implicits._
 import doodle.core._
 import doodle.syntax._
 import doodle.random._
+import doodle.backend.Canvas
 
 object SandSpline {
-  val color = Color.lightSkyBlue.alpha(0.01.normalized)
-  val dot = Image.circle(0.5).fillColor(color).noLine
+  val color = Color.darkSlateBlue.alpha(0.01.normalized)
+  val dc = DrawingContext.empty.fillColor(color)
 
+  def dot(canvas: Canvas, location: Point): Unit =
+    canvas.circle(
+      dc,
+      location.x,
+      location.y,
+      0.5
+    )
 
-  val samples = 200
+  val samples = 400
   /* Draw one sand spline */
-  def sandSpline(pts: List[Point]): Image = {
+  def sandSpline(canvas: Canvas, pts: List[Point]): Unit = {
     val spline = Parametric.interpolate(pts)
-    def sand(t: Normalized): Image =
-      dot.at(spline(t).toVec)
+    def sand(t: Normalized): Unit = {
+      val loc = spline(t)
+      dot(canvas, loc)
+    }
 
-    def iter(count: Int, accum: Image): Image =
+    def loop(count: Int): Unit =
       count match {
-        case 0 => sand(0.normalized) on accum
+        case 0 => sand(0.normalized)
         case n =>
           val t = (n.toDouble / samples).normalized
-          iter(n-1, sand(t) on accum)
+          sand(t)
+          loop(n-1)
       }
 
-    iter(samples, Image.empty)
+    loop(samples)
   }
 
   def noise(t: Normalized): Random[Vec] = {
-    val stdDev = t.get * 20
+    val stdDev = t.get * 80
     val noise = Random.normal(0.0, stdDev)
     (noise |@| noise).map((x, y) => Vec(x, y))
   }
@@ -41,7 +52,7 @@ object SandSpline {
   /*
    * Draw `count` sand splines, where the points for each spline are generated from a parametric curve distorted by increasing amounts of noise
    */
-  def sandSplines(curve: Normalized => Point, count: Int = 400): Random[Image] = {
+  def sandSplines(canvas: Canvas, curve: Normalized => Point, count: Int = 400): Random[List[Point]] = {
     def sample: List[Point] =
       (0.0 to 1.0 by 0.02).foldLeft(List.empty[Point]){ (accum, t) =>
         curve(t.normalized) :: accum
@@ -52,25 +63,28 @@ object SandSpline {
         perturb((i.toDouble / count).normalized, pt)
       }.sequence
 
-    def iter(count: Int, accum: Random[List[List[Point]]]): Random[List[List[Point]]] =
+    def iter(count: Int, last: Random[List[Point]]): Random[List[Point]] =
       count match {
-        case 0 => accum
+        case 0 => last
         case n =>
-          val nextAccum =
+          val next =
             for {
-              pts <- accum
-              ps  <- step(pts.head)
-            } yield ps :: pts
-          iter(n-1, nextAccum)
-        }
+              pts  <- last
+              _     = sandSpline(canvas, pts)
+              next <- step(pts)
+            } yield next
+          iter(n-1, next)
+      }
 
-    iter(count, Random.always(List(sample))).map(pts => allOn(pts.map(sandSpline _)))
+    iter(count, Random.always(sample))
   }
 
-  def ofSize(count: Int) =
-    sandSplines(Parametric.circle(100).toNormalizedCurve, count)
+  def ofSize(count: Int): Image =
+    Image.draw(400, 400){ canvas =>
+      sandSplines(canvas, Parametric.circle(100).toNormalizedCurve, count).run
+    } on Image.square(400).fillColor(Color.black)
 
   val image =
-    ofSize(400).map{ img => img on Image.square(400).fillColor(Color.black)}
+    ofSize(10000)
 
 }


### PR DESCRIPTION
`Image.draw` allows the user to provide a method that draws directly on the
canvas. This is generally faster than constructing an `Image` graph representing
an equivalent output and is the only way to render images with millions of
components. It is also arguably more suitable for certain types of output (e.g
images where there is little structure.)

Closes #43