### PR TITLE
Gradient support

### DIFF
--- a/js/src/main/scala/doodle/js/Svg.scala
+++ b/js/src/main/scala/doodle/js/Svg.scala
@@ -64,9 +64,9 @@ object Svg {
   }
 
   def toSvgSpreadMethod(cycleMethod: Gradient.CycleMethod): String = cycleMethod match {
-    case _: Gradient.CycleMethod.NoCycle => "pad"
-    case _: Gradient.CycleMethod.Reflect => "reflect"
-    case _: Gradient.CycleMethod.Repeat => "repeat"
+    case Gradient.CycleMethod.NoCycle => "pad"
+    case Gradient.CycleMethod.Reflect => "reflect"
+    case Gradient.CycleMethod.Repeat => "repeat"
   }
 
   def toSvgGradientStop(tuple: (Color, Double)): dom.svg.Stop = {

--- a/js/src/main/scala/doodle/js/Svg.scala
+++ b/js/src/main/scala/doodle/js/Svg.scala
@@ -3,13 +3,33 @@ package js
 
 import doodle.core._
 import doodle.core.transform.Transform
+import org.scalajs.dom
+import org.scalajs.dom.svg.Defs
 
 /** Utilities for working with SVG */
 object Svg {
+  import scalatags.JsDom.{svgTags => svg}
+  import scalatags.JsDom.svgAttrs
+  import scalatags.JsDom.implicits._
+  import scalatags.JsDom.all.attr
+
+  def addGradientToSvg(gradient: Gradient, defs: Defs) = {
+    val queryResult = defs.querySelector(s"#${this.toGradientId(gradient)}")
+    if (queryResult == null)
+      defs.appendChild(this.toSvgGradient(gradient))
+  }
+
   def toHSLA(color: Color): String = {
     val (h, s, l, a) = (color.hue, color.saturation, color.lightness, color.alpha)
     s"hsla(${h.toDegrees}, ${s.toPercentage}, ${l.toPercentage}, ${a.get})"
   }
+
+  def toRGB(color: Color): String = {
+    val (r, g, b) = (color.red, color.green, color.blue)
+    s"rgb(${r.get}, ${g.get}, ${b.get})"
+  }
+
+  def toGradientId(gradient: Gradient): String = s"grad_${gradient.hashCode()}"
 
   def toStyle(dc: DrawingContext): String = {
     import scala.collection.mutable.StringBuilder
@@ -34,11 +54,55 @@ object Svg {
     }
 
     dc.fill.fold(builder ++= "fill: none; ") {
-      case Fill(color) =>
+      case Fill.Color(color) =>
         builder ++= s"fill: ${toHSLA(color)}; "
+      case Fill.Gradient(gradient) =>
+        builder ++= s"fill: url(#${toGradientId(gradient)}); "
     }
 
     builder.toString
+  }
+
+  def toSvgSpreadMethod(cycleMethod: Gradient.CycleMethod): String = cycleMethod match {
+    case _: Gradient.CycleMethod.NoCycle => "pad"
+    case _: Gradient.CycleMethod.Reflect => "reflect"
+    case _: Gradient.CycleMethod.Repeat => "repeat"
+  }
+
+  def toSvgGradientStop(tuple: (Color, Double)): dom.svg.Stop = {
+    val offset = tuple._2
+    val color = this.toRGB(tuple._1)
+    val opacity = tuple._1.alpha.get
+    svg.stop(svgAttrs.offset:=offset, svgAttrs.stopColor:=color, svgAttrs.stopOpacity:=opacity).render
+  }
+
+  def toSvgGradient(gradient: Gradient): dom.svg.Element = gradient match {
+    case linear: Gradient.Linear => this.toSvgLinearGradient(linear)
+    case radial: Gradient.Radial => this.toSvgRadialGradient(radial)
+  }
+
+  def toSvgLinearGradient(gradient: Gradient.Linear): dom.svg.LinearGradient = {
+    val (x1, y1, x2, y2) = (gradient.start.x, gradient.start.y, gradient.end.x, gradient.end.y)
+    val id = this.toGradientId(gradient)
+    val spreadMethod = this.toSvgSpreadMethod(gradient.cycleMethod)
+    val domGradient = svg.linearGradient(svgAttrs.id:=id, svgAttrs.x1:=x1, svgAttrs.y1:=y1, svgAttrs.x2:=x2,
+      svgAttrs.y2:=y2, svgAttrs.spreadMethod:=spreadMethod, svgAttrs.gradientUnits:="userSpaceOnUse").render
+    val stops = gradient.stops.map(this.toSvgGradientStop)
+    stops.foreach(domGradient.appendChild(_))
+
+    domGradient
+  }
+
+  def toSvgRadialGradient(gradient: Gradient.Radial): dom.svg.RadialGradient = {
+    val (cx, cy, fx, fy, r) = (gradient.outer.x, gradient.outer.y, gradient.inner.x, gradient.inner.y, gradient.radius)
+    val id = this.toGradientId(gradient)
+    val spreadMethod = this.toSvgSpreadMethod(gradient.cycleMethod)
+    val domGradient = svg.radialGradient(svgAttrs.id:=id, svgAttrs.cx:=cx, svgAttrs.cy:=cy, attr("fx"):=fx,
+      attr("fy"):=fy, svgAttrs.r:=r, svgAttrs.spreadMethod:=spreadMethod, svgAttrs.gradientUnits:="userSpaceOnUse").render
+    val stops = gradient.stops.map(this.toSvgGradientStop)
+    stops.foreach(domGradient.appendChild(_))
+
+    domGradient
   }
 
   def toSvgPath(elts: List[PathElement]): String = {

--- a/js/src/main/scala/doodle/js/SvgCanvas.scala
+++ b/js/src/main/scala/doodle/js/SvgCanvas.scala
@@ -7,7 +7,7 @@ import doodle.backend.{BoundingBox, Canvas}
 
 import org.scalajs.dom
 
-final class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
+final class SvgCanvas(root: dom.svg.G, defs: dom.svg.Defs, center: Point, screenCenter: Point)
     extends Canvas {
   import scalatags.JsDom.styles.{font => cssFont}
   import scalatags.JsDom.{svgTags => svg}
@@ -39,6 +39,8 @@ final class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
     val style = Svg.toStyle(context)
     val elt = svg.path(currentTransform, svgAttrs.style:=style, svgAttrs.d:=dAttr).render
     root.appendChild(elt)
+
+    context.fillGradient.foreach(Svg.addGradientToSvg(_, defs))
   }
 
   def openPath(context: DrawingContext, elements: List[PathElement]): Unit = {
@@ -46,6 +48,8 @@ final class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
     val style = Svg.toStyle(context)
     val elt = svg.path(currentTransform, svgAttrs.style:=style, svgAttrs.d:=dAttr).render
     root.appendChild(elt)
+
+    context.fillGradient.foreach(Svg.addGradientToSvg(_, defs))
   }
 
   def text(context: DrawingContext,
@@ -67,6 +71,8 @@ final class SvgCanvas(root: dom.svg.G, center: Point, screenCenter: Point)
                          cssFont:=font,
                          characters).render
       root.appendChild(elt)
+
+      context.fillGradient.foreach(Svg.addGradientToSvg(_, defs))
     }
   }
 }

--- a/js/src/main/scala/doodle/js/SvgCanvas.scala
+++ b/js/src/main/scala/doodle/js/SvgCanvas.scala
@@ -40,7 +40,7 @@ final class SvgCanvas(root: dom.svg.G, defs: dom.svg.Defs, center: Point, screen
     val elt = svg.path(currentTransform, svgAttrs.style:=style, svgAttrs.d:=dAttr).render
     root.appendChild(elt)
 
-    context.fillGradient.foreach(Svg.addGradientToSvg(_, defs))
+    reportFill(context.fill)
   }
 
   def openPath(context: DrawingContext, elements: List[PathElement]): Unit = {
@@ -49,7 +49,7 @@ final class SvgCanvas(root: dom.svg.G, defs: dom.svg.Defs, center: Point, screen
     val elt = svg.path(currentTransform, svgAttrs.style:=style, svgAttrs.d:=dAttr).render
     root.appendChild(elt)
 
-    context.fillGradient.foreach(Svg.addGradientToSvg(_, defs))
+    reportFill(context.fill)
   }
 
   def text(context: DrawingContext,
@@ -72,7 +72,12 @@ final class SvgCanvas(root: dom.svg.G, defs: dom.svg.Defs, center: Point, screen
                          characters).render
       root.appendChild(elt)
 
-      context.fillGradient.foreach(Svg.addGradientToSvg(_, defs))
+      reportFill(context.fill)
     }
+  }
+
+  private def reportFill(fill: Option[Fill]) = fill match {
+    case Some(Fill.Gradient(g)) => Svg.addGradientToSvg(g, defs)
+    case _ =>
   }
 }

--- a/js/src/main/scala/doodle/js/SvgFrame.scala
+++ b/js/src/main/scala/doodle/js/SvgFrame.scala
@@ -35,7 +35,10 @@ final class SvgFrame(svgCanvas: dom.svg.SVG,
       svg.g(svgAttrs.transform:=Svg.toSvgTransform(canvasToScreen)).render
     svgCanvas.appendChild(root)
 
-    val canvas = new SvgCanvas(root, center, screenCenter)
+    val defs = svg.defs().render
+    svgCanvas.appendChild(defs)
+
+    val canvas = new SvgCanvas(root, defs, center, screenCenter)
     renderer.run(canvas)(finalised)
   }
 }

--- a/jvm/src/main/scala/doodle/jvm/Java2D.scala
+++ b/jvm/src/main/scala/doodle/jvm/Java2D.scala
@@ -40,9 +40,9 @@ object Java2D {
   }
 
   def toAwtCycleMethod(cycleMethod: Gradient.CycleMethod): AwtCycleMethod = cycleMethod match {
-    case _: Gradient.CycleMethod.NoCycle => AwtCycleMethod.NO_CYCLE
-    case _: Gradient.CycleMethod.Reflect => AwtCycleMethod.REFLECT
-    case _: Gradient.CycleMethod.Repeat => AwtCycleMethod.REPEAT
+    case Gradient.CycleMethod.NoCycle => AwtCycleMethod.NO_CYCLE
+    case Gradient.CycleMethod.Reflect => AwtCycleMethod.REFLECT
+    case Gradient.CycleMethod.Repeat => AwtCycleMethod.REPEAT
   }
 
   def toLinearGradientPaint(gradient: Gradient.Linear): LinearGradientPaint = {
@@ -90,12 +90,9 @@ object Java2D {
     graphics.setPaint(jColor)
   }
 
-  def setFill(graphics: Graphics2D, fill: Color) = {
-    graphics.setPaint(this.toAwtColor(fill))
-  }
-
-  def setFill(graphics: Graphics2D, fill: Gradient) = {
-    graphics.setPaint(this.toMultipleGradientPaint(fill))
+  def setFill(graphics: Graphics2D, fill: Fill) = fill match {
+    case Fill.Color(color) => graphics.setPaint(this.toAwtColor(color))
+    case Fill.Gradient(gradient) => graphics.setPaint(this.toMultipleGradientPaint(gradient))
   }
 
   /** Converts to an *open* `Path2D` */
@@ -133,11 +130,7 @@ object Java2D {
       setStroke(graphics, s)
       graphics.draw(path)
     }
-    current.fillColor.foreach { f =>
-      setFill(graphics, f)
-      graphics.fill(path)
-    }
-    current.fillGradient.foreach { f =>
+    current.fill.foreach { f =>
       setFill(graphics, f)
       graphics.fill(path)
     }

--- a/jvm/src/main/scala/doodle/jvm/Java2DCanvas.scala
+++ b/jvm/src/main/scala/doodle/jvm/Java2DCanvas.scala
@@ -76,7 +76,7 @@ final class Java2DCanvas(graphics: Graphics2D, center: Point, screenCenter: Poin
     context.stroke.foreach { s =>
       Java2D.setStroke(graphics, s)
     }
-    context.fillColor.foreach { f =>
+    context.fill.foreach { f =>
       Java2D.setFill(graphics, f)
     }
     context.font map { f =>

--- a/shared/src/main/scala/doodle/core/DrawingContext.scala
+++ b/shared/src/main/scala/doodle/core/DrawingContext.scala
@@ -13,14 +13,18 @@ final case class DrawingContext(
   lineJoin: Option[Line.Join],
 
   fillColor: Option[Color],
+  fillGradient: Option[Gradient],
 
   font: Option[Font]
 ) {
   def stroke: Option[Stroke] =
     (lineWidth |@| lineColor |@| lineCap |@| lineJoin) map { Stroke.apply _ }
 
-  def fill: Option[Fill] =
-    fillColor.map(Fill.apply _)
+  // Prefer gradient over color
+  def fill: Option[Fill] = fillGradient match {
+    case Some(g) => Some(Fill.Gradient(g))
+    case None => fillColor.map(Fill.Color.apply _)
+  }
 
   // A lens library would help to reduce this redundancy in the
   // DrawingContext transformations. However, in the introductory
@@ -42,11 +46,17 @@ final case class DrawingContext(
   def fillColorTransform(f: Color => Color): DrawingContext =
     this.copy(fillColor = fillColor.map(f))
 
+  def fillGradient(gradient: Gradient): DrawingContext =
+    this.copy(fillGradient = Some(gradient))
+
+  def fillGradientTransform(f: Gradient => Gradient): DrawingContext =
+    this.copy(fillGradient = fillGradient.map(f))
+
   def noLine: DrawingContext =
     this.copy(lineWidth = None)
 
   def noFill: DrawingContext =
-    this.copy(fillColor = None)
+    this.copy(fillColor = None, fillGradient = None)
 
   def font(font: Font): DrawingContext =
     this.copy(font = Some(font))
@@ -60,6 +70,7 @@ object DrawingContext {
       lineCap = None,
       lineJoin = None,
       fillColor = None,
+      fillGradient = None,
       font = None
     )
   val whiteLines =
@@ -69,6 +80,7 @@ object DrawingContext {
       lineCap = Some(Line.Cap.Butt),
       lineJoin = Some(Line.Join.Miter),
       fillColor = None,
+      fillGradient = None,
       font = Some(Font.defaultSerif)
     )
   val blackLines =
@@ -78,6 +90,7 @@ object DrawingContext {
       lineCap = Some(Line.Cap.Butt),
       lineJoin = Some(Line.Join.Miter),
       fillColor = None,
+      fillGradient = None,
       font = Some(Font.defaultSerif)
     )
 }

--- a/shared/src/main/scala/doodle/core/Gradient.scala
+++ b/shared/src/main/scala/doodle/core/Gradient.scala
@@ -1,0 +1,25 @@
+package doodle.core
+
+sealed trait Gradient extends Product with Serializable {}
+
+object Gradient {
+  final case class Linear(start: Point, end: Point, stops: Seq[(Color, Double)], cycleMethod: CycleMethod) extends Gradient
+  final case class Radial(outer: Point, inner: Point, radius: Double, stops: Seq[(Color, Double)], cycleMethod: CycleMethod) extends Gradient
+
+  def DichromaticVertical(color1: Color, color2: Color, length: Double) =
+    Linear(Point.zero, Point.Cartesian(0, length), List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat())
+
+  def DichromaticHorizontal(color1: Color, color2: Color, length: Double) =
+    Linear(Point.zero, Point.Cartesian(length, 0), List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat())
+
+  def DichromaticRadial(color1: Color, color2: Color, radius: Double) =
+    Radial(Point.zero, Point.zero, radius, List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat())
+
+  sealed trait CycleMethod extends Product with Serializable {}
+
+  object CycleMethod {
+    final case class NoCycle() extends CycleMethod
+    final case class Reflect() extends CycleMethod
+    final case class Repeat() extends CycleMethod
+  }
+}

--- a/shared/src/main/scala/doodle/core/Gradient.scala
+++ b/shared/src/main/scala/doodle/core/Gradient.scala
@@ -6,20 +6,20 @@ object Gradient {
   final case class Linear(start: Point, end: Point, stops: Seq[(Color, Double)], cycleMethod: CycleMethod) extends Gradient
   final case class Radial(outer: Point, inner: Point, radius: Double, stops: Seq[(Color, Double)], cycleMethod: CycleMethod) extends Gradient
 
-  def DichromaticVertical(color1: Color, color2: Color, length: Double) =
-    Linear(Point.zero, Point.Cartesian(0, length), List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat())
+  def dichromaticVertical(color1: Color, color2: Color, length: Double) =
+    Linear(Point.zero, Point.Cartesian(0, length), List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat)
 
-  def DichromaticHorizontal(color1: Color, color2: Color, length: Double) =
-    Linear(Point.zero, Point.Cartesian(length, 0), List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat())
+  def dichromaticHorizontal(color1: Color, color2: Color, length: Double) =
+    Linear(Point.zero, Point.Cartesian(length, 0), List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat)
 
-  def DichromaticRadial(color1: Color, color2: Color, radius: Double) =
-    Radial(Point.zero, Point.zero, radius, List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat())
+  def dichromaticRadial(color1: Color, color2: Color, radius: Double) =
+    Radial(Point.zero, Point.zero, radius, List((color1, 0.0), (color2, 1.0)), CycleMethod.Repeat)
 
   sealed trait CycleMethod extends Product with Serializable {}
 
   object CycleMethod {
-    final case class NoCycle() extends CycleMethod
-    final case class Reflect() extends CycleMethod
-    final case class Repeat() extends CycleMethod
+    final case object NoCycle extends CycleMethod
+    final case object Reflect extends CycleMethod
+    final case object Repeat extends CycleMethod
   }
 }

--- a/shared/src/main/scala/doodle/core/Image.scala
+++ b/shared/src/main/scala/doodle/core/Image.scala
@@ -42,6 +42,12 @@ sealed abstract class Image extends Product with Serializable {
   def fillColorTransform(f: Color => Color): Image =
     ContextTransform(_.fillColorTransform(f), this)
 
+  def fillGradient(gradient: Gradient): Image =
+    ContextTransform(_.fillGradient(gradient), this)
+
+  def fillGradientTransform(f: Gradient => Gradient): Image =
+    ContextTransform(_.fillGradientTransform(f), this)
+
   def noLine: Image =
     ContextTransform(_.noLine, this)
 

--- a/shared/src/main/scala/doodle/core/Style.scala
+++ b/shared/src/main/scala/doodle/core/Style.scala
@@ -31,4 +31,10 @@ object Line {
 }
 
 final case class Stroke(width: Double, color: Color, cap: Line.Cap, join: Line.Join)
-final case class Fill(color: Color)
+
+sealed trait Fill
+
+object Fill {
+  final case class Color(color: doodle.core.Color) extends Fill
+  final case class Gradient(gradient: doodle.core.Gradient) extends Fill
+}

--- a/shared/src/main/scala/doodle/examples/GradientCircles.scala
+++ b/shared/src/main/scala/doodle/examples/GradientCircles.scala
@@ -1,0 +1,12 @@
+package doodle.examples
+
+import doodle.core._
+
+object GradientCircles {
+
+  val grad = Gradient.DichromaticRadial(Color.red, Color.blue, 100.0)
+
+  val gradientCircle = Image.circle(100) fillGradient grad
+
+  val image = gradientCircle above gradientCircle
+}

--- a/shared/src/main/scala/doodle/examples/GradientCircles.scala
+++ b/shared/src/main/scala/doodle/examples/GradientCircles.scala
@@ -4,7 +4,7 @@ import doodle.core._
 
 object GradientCircles {
 
-  val grad = Gradient.DichromaticRadial(Color.red, Color.blue, 100.0)
+  val grad = Gradient.dichromaticRadial(Color.red, Color.blue, 100.0)
 
   val gradientCircle = Image.circle(100) fillGradient grad
 

--- a/shared/src/main/scala/doodle/examples/GradientSquares.scala
+++ b/shared/src/main/scala/doodle/examples/GradientSquares.scala
@@ -1,0 +1,14 @@
+package doodle.examples
+
+import doodle.core._
+
+object GradientSquares {
+
+  val width = 100.0
+
+  val grad = Gradient.DichromaticVertical(Color.red, Color.blue, width)
+
+  val gradientSquare = Image.square(width) fillGradient grad
+
+  val image = gradientSquare above gradientSquare
+}

--- a/shared/src/main/scala/doodle/examples/GradientSquares.scala
+++ b/shared/src/main/scala/doodle/examples/GradientSquares.scala
@@ -6,7 +6,7 @@ object GradientSquares {
 
   val width = 100.0
 
-  val grad = Gradient.DichromaticVertical(Color.red, Color.blue, width)
+  val grad = Gradient.dichromaticVertical(Color.red, Color.blue, width)
 
   val gradientSquare = Image.square(width) fillGradient grad
 


### PR DESCRIPTION
Hello. This PR brings gradient fill support for Doodle (issue #45). I did some research on the topic of gradient APIs in SVG and Java2D, and it turned out they are pretty much the same, except for the SVG allowing to choose between two coordinate systems (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/gradientUnits), one of which (namely `userSpaceOnUse`) is compilant with Java2D coordinate system. Therefore, it was pretty straightforward to abstract the intersection of both worlds and implement it. The changes are not too invasive in `shared` nor `jvm`, but it required more changes in `js`. The reason for this is that SVG gradients need to be first defined in `<defs>` tag (preferably in the root `<svg>` element), and then referenced to by their ids. Therefore, I define the `<defs>` element in `SVGFrame` and then pass it as an argument to `SVGCanvas`.

Demos:
http://i.imgur.com/M8SBulU.png (`examples.GradientCircles`)
http://i.imgur.com/kdY7rxt.png (`examples.GradientSquares`)

Useful links:
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/radialGradient
https://docs.oracle.com/javase/7/docs/api/java/awt/LinearGradientPaint.html
https://docs.oracle.com/javase/7/docs/api/java/awt/RadialGradientPaint.html