### PR TITLE
upgrade to dbuild-friendly version of sbt-bintray

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
 addSbtPlugin("com.lihaoyi" % "workbench" % "0.2.3")
-//addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.4.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 


### PR DESCRIPTION
if this is merged, we'll no longer need to use a forked version
of doodle in the Scala community build